### PR TITLE
Fixes for zerohedge.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35270,6 +35270,14 @@ INVERT
 
 ================================
 
+zerohedge.com
+*.zerohedge.com
+
+INVERT
+* header > * img
+
+================================
+
 zerossl.com
 
 INVERT


### PR DESCRIPTION
Invert images in the header:

Before:
![zerohedge_before](https://github.com/user-attachments/assets/dcf42569-1f33-4a0f-93ed-09dba39dcf2d)

After:
![zerohedge_after](https://github.com/user-attachments/assets/512023f4-b47a-4e27-a550-c07048e30907)

